### PR TITLE
Fix: recruitments_name slot was missing in domain.yml

### DIFF
--- a/domain.yml
+++ b/domain.yml
@@ -72,6 +72,10 @@ slots:
     type: text
     auto_fill: True
 
+  recruitments_name:
+    type: text
+    auto_fill: True
+
   scheme_name:
     type: text
     auto_fill: True


### PR DESCRIPTION
Added slot for recruitments_name which was missing from domain.yml.